### PR TITLE
Feature/task data view

### DIFF
--- a/RepeatReminder/RepeatReminder.xcodeproj/project.pbxproj
+++ b/RepeatReminder/RepeatReminder.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		FDEAA6232B24504B003DB9DA /* TaskListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEAA6222B24504B003DB9DA /* TaskListViewModel.swift */; };
 		FDEAA6252B245220003DB9DA /* TaskList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEAA6242B245220003DB9DA /* TaskList.swift */; };
 		FDEAA6272B246479003DB9DA /* TaskListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEAA6262B246479003DB9DA /* TaskListTests.swift */; };
+		FDEE0C302B3D064100B97C41 /* TaskCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEE0C2F2B3D064100B97C41 /* TaskCellViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		FDEAA6222B24504B003DB9DA /* TaskListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListViewModel.swift; sourceTree = "<group>"; };
 		FDEAA6242B245220003DB9DA /* TaskList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskList.swift; sourceTree = "<group>"; };
 		FDEAA6262B246479003DB9DA /* TaskListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListTests.swift; sourceTree = "<group>"; };
+		FDEE0C2F2B3D064100B97C41 /* TaskCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCellViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +212,7 @@
 		FD9336BF2B036DFC002FD8C9 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				FDEE0C2F2B3D064100B97C41 /* TaskCellViewModel.swift */,
 				FDEAA6222B24504B003DB9DA /* TaskListViewModel.swift */,
 				FD9336BB2B03586D002FD8C9 /* TaskAddEditViewModel.swift */,
 			);
@@ -362,6 +365,7 @@
 				FDEAA6232B24504B003DB9DA /* TaskListViewModel.swift in Sources */,
 				FD28145F2B130ABF008429E1 /* Task.swift in Sources */,
 				FD28145D2B1308AE008429E1 /* DB.swift in Sources */,
+				FDEE0C302B3D064100B97C41 /* TaskCellViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RepeatReminder/RepeatReminder/Domain/Model/TaskList.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Model/TaskList.swift
@@ -17,7 +17,12 @@ struct TaskList {
         }
         
         do {
-            self.tasks = try db.getTasks(isCompleted: isCompleted, isDeleted: isDeleted)
+            let taskList = try db.getTasks(isCompleted: isCompleted, isDeleted: isDeleted)
+            /// 締め切り順にソート
+            let sortedTasks = taskList.sorted(by: { leftTask, rightTask -> Bool in
+                return leftTask.deadline < rightTask.deadline
+            })
+            self.tasks = sortedTasks
             return
         } catch {
             return

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  TaskCellViewModel.swift
+//  RepeatReminder
+//
+//  Created by 吉田郁吹 on 2023/12/28.
+//
+
+import Foundation
+import SwiftUI
+
+class TaskCellViewModel: ObservableObject {
+    var task: Task?
+    
+    func setTask(task:Task){
+        self.task = task
+    }
+    
+    var name: String {
+        guard (self.task != nil) else {
+            return ""
+        }
+        return task!.name
+    }
+    
+    var deadline: String {
+        guard (self.task != nil) else {
+            return ""
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM月dd日 HH:mm"
+        let dateString = formatter.string(from: task!.deadline)
+        return dateString
+    }
+    
+    var remainingDays: String {
+        guard (self.task != nil) else {
+            return ""
+        }
+        let deadline = Calendar.current.startOfDay(for: task!.deadline)
+        let today = Calendar.current.startOfDay(for: Date())
+        let remainingDays = Calendar.current.dateComponents([.day], from: today, to: deadline).day!
+        return String(remainingDays)
+    }
+}

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
@@ -32,13 +32,52 @@ class TaskCellViewModel: ObservableObject {
         return dateString
     }
     
-    var remainingDays: String {
+    private var remainingDays: Int {
         guard (self.task != nil) else {
-            return ""
+            return 0
         }
         let deadline = Calendar.current.startOfDay(for: task!.deadline)
         let today = Calendar.current.startOfDay(for: Date())
         let remainingDays = Calendar.current.dateComponents([.day], from: today, to: deadline).day!
-        return String(remainingDays)
+        return remainingDays
+    }
+    
+    private var remainingYears: Int {
+        guard (self.task != nil) else {
+            return 0
+        }
+        let deadline = Calendar.current.startOfDay(for: task!.deadline)
+        let today = Calendar.current.startOfDay(for: Date())
+        let remainingDays = Calendar.current.dateComponents([.day], from: today, to: deadline).day!
+        return Int(remainingDays/365)
+    }
+    
+    var remainingNumText: Text {
+        var remaining = ""
+        if remainingDays < 365 {
+            remaining = String(abs(remainingDays))
+        } else {
+            remaining = String(abs(remainingYears))
+        }
+        if remaining.count < 3 {
+            return Text(remaining).font(.largeTitle)
+        } else {
+            return Text(remaining).font(.title)
+        }
+    }
+    
+    var remainingText: String {
+        var remaining = ""
+        if remainingDays < 365 {
+            remaining = "日"
+        } else {
+            remaining = "年"
+        }
+        if remainingDays < 0 {
+            remaining = remaining + "前"
+        } else {
+            remaining = remaining + "後"
+        }
+        return remaining
     }
 }

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
@@ -73,7 +73,7 @@ class TaskCellViewModel: ObservableObject {
         } else {
             remaining = "年"
         }
-        if remainingDays < 0 {
+        if self.task!.deadline < Date() {
             remaining = remaining + "前"
         } else {
             remaining = remaining + "後"

--- a/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
@@ -8,14 +8,18 @@
 import SwiftUI
 
 struct TaskCell: View {
-    let task: Task
+    @ObservedObject var viewModel=TaskCellViewModel()
+    
+    init(task: Task) {
+        viewModel.setTask(task:task)
+    }
     
     var body: some View {
         HStack(spacing:8){
             // タスクの情報を表示
             HStack{
                 HStack{
-                    Text("1")
+                    Text(viewModel.remainingDays)
                         .font(.largeTitle)
                         .padding(.top,20)
                         .padding(.bottom,12)
@@ -29,8 +33,8 @@ struct TaskCell: View {
                 .padding(.leading,4)
                 .frame(width:96)
                 VStack(spacing:16){
-                    Text(task.name)
-                    Text("10月10日 14:00")
+                    Text(viewModel.name)
+                    Text(viewModel.deadline)
                 }.foregroundColor(Color("TextColor"))
                     .frame(width:160,height:88)
                     .background(Color("BackgroundColor"))
@@ -44,7 +48,7 @@ struct TaskCell: View {
             VStack(spacing:4){
                 ZStack {
                     NavigationLink(
-                        destination: TaskAddEditView(isEditing:true,task:task)
+                        destination: TaskAddEditView(isEditing:true,task:viewModel.task)
                     ){ EmptyView() }.opacity(0)
                     Image(systemName:"pencil.circle")
                         .foregroundColor(Color("ButtonColor"))

--- a/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
@@ -18,14 +18,10 @@ struct TaskCell: View {
         HStack(spacing:8){
             // タスクの情報を表示
             HStack{
-                HStack{
-                    Text(viewModel.remainingDays)
-                        .font(.largeTitle)
-                        .padding(.top,20)
-                        .padding(.bottom,12)
-                    Text("日後")
-                        .font(.title2)
-                        .padding(.top,24)
+                HStack(spacing:4){
+                    viewModel.remainingNumText
+                    Text(viewModel.remainingText)
+                        .padding(.top,32)
                         .padding(.bottom,4)
                 }
                 .foregroundColor(Color("BackgroundColor"))

--- a/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/Component/TaskCell.swift
@@ -28,10 +28,12 @@ struct TaskCell: View {
                 .fontWeight(.bold)
                 .padding(.leading,4)
                 .frame(width:96)
-                VStack(spacing:16){
+                VStack(alignment:.leading,spacing:8){
                     Text(viewModel.name)
                     Text(viewModel.deadline)
                 }.foregroundColor(Color("TextColor"))
+                    .padding(.leading,8)
+                    .padding(.trailing,8)
                     .frame(width:160,height:88)
                     .background(Color("BackgroundColor"))
                     .cornerRadius(10)

--- a/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct TaskAddEditView: View {
-    var isEditing: Bool
-    var task: Task?
+    let isEditing: Bool
     
     @Environment(\.presentationMode) var presentation
     @FocusState private var focusedField: Bool?
@@ -215,7 +214,7 @@ struct TaskAddEditView: View {
                             }
                         }){
                             if isEditing {
-                                Text("編 集")
+                                Text("保 存")
                                     .fontWeight(.bold)
                                     .font(.title2)
                                     .foregroundColor(Color("BackgroundColor"))

--- a/RepeatReminder/RepeatReminder/Presentation/Views/TaskListView.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/TaskListView.swift
@@ -22,18 +22,20 @@ struct TaskListView: View {
                             .foregroundColor(Color("BackgroundColor"))
                             .fontWeight(.bold)
                             .font(.title2)
-                            .padding(.top,20)
+                            .padding(.top,16)
                             .padding(.bottom,8)
-                        VStack{
-                            ForEach(viewModel.todayTasks.indices, id: \.self) { index in
-                                Text(viewModel.todayTasks[index]).font(.title3)
+                        ScrollView{
+                            VStack(alignment:.leading,spacing:8){
+                                ForEach(viewModel.todayTasks.indices, id: \.self) { index in
+                                    Text(viewModel.todayTasks[index]).font(.title3)
+                                }
                             }
                         }.foregroundColor(Color("TextColor"))
                             .padding()
-                            .frame(width:296,height:152,alignment:.topLeading)
+                            .frame(width:296,height:168,alignment:.topLeading)
                             .background(Color("BackgroundColor"))
                             .cornerRadius(10)
-                    }.frame(width:328,height:232,alignment:.top)
+                    }.frame(width:328,height:240,alignment:.top)
                         .background(Color("MainColor"))
                         .cornerRadius(15)
                         .compositingGroup()
@@ -85,7 +87,7 @@ struct TaskListView: View {
                         }.listRowSeparator(.hidden)
                     }.scrollContentBackground(.hidden)
                         .listStyle(PlainListStyle())
-                }.padding(.top,40)
+                }.padding(.top,32)
             }.onAppear {
                 viewModel.readTask()
             }


### PR DESCRIPTION
## 概要
タスクの表示の形式を調整

## 詳細
- 残り日数、締め切り日時の表示
- 残り日数の表示に「日後」「年後」「日前」「年前」を適用
- 残り日数の数字が大きい場合の文字の大きさを調整
- タスク一覧を締め切り順に並べて表示
- タスクの名前が長い時に自然な位置に来るようにレイアウトを調整

Closes #21