### PR TITLE
Fix/notification

### DIFF
--- a/RepeatReminder/RepeatReminder.xcodeproj/project.pbxproj
+++ b/RepeatReminder/RepeatReminder.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RepeatReminder/development.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -615,6 +616,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = RepeatReminder/production.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/RepeatReminder/RepeatReminder/Domain/Entities/AppNotification.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Entities/AppNotification.swift
@@ -10,13 +10,13 @@ import Foundation
 struct AppNotification {
     var notificationId: String
     var taskId: String
-    var datetime: Date
+    var delay: Int
     var isLimit: Bool
     
-    init(notificationId: String, taskId: String, datetime: Date, isLimit: Bool) {
+    init(notificationId: String, taskId: String, delay: Int, isLimit: Bool) {
         self.notificationId = notificationId
         self.taskId = taskId
-        self.datetime = datetime
+        self.delay = delay
         self.isLimit = isLimit
     }
 }

--- a/RepeatReminder/RepeatReminder/Domain/Models/TaskList.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Models/TaskList.swift
@@ -40,7 +40,10 @@ struct TaskList {
             let deadline = calendar.dateComponents([.year, .month, .day], from: task.deadline)
             
             if today == deadline {
-                nameList.append(task.name)
+                // タスク名が空の時はスキップ
+                if task.name != "" {
+                    nameList.append(task.name)
+                }
             }
         }
         

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationDB.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationDB.swift
@@ -210,7 +210,6 @@ final class NotificationDB{
             
             let notification = AppNotification(notificationId:notificationId,taskId:taskId,datetime:datetime,isLimit:isLimit)
             
-            print(notificationId)
             notifications.append(notification)
         }
         sqlite3_finalize(stmt)

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationDB.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationDB.swift
@@ -21,7 +21,7 @@ enum NotificationDatabaseError: Error {
 final class NotificationDB{
     static let shared = NotificationDB()
     
-    private let dbFile = "NotificationDBVer3.sqlite"
+    private let dbFile = "NotificationDBVer4.sqlite"
     private var db: OpaquePointer?
     
     private init?() {
@@ -58,7 +58,7 @@ final class NotificationDB{
         CREATE TABLE IF NOT EXISTS notifications (
             notification_id TEXT NOT NULL PRIMARY KEY,
             task_id TEXT NOT NULL,
-            datetime TEXT NOT NULL,
+            delay INTEGER NOT NULL,
             is_limit INTEGER NULL
         );
         """
@@ -90,7 +90,7 @@ final class NotificationDB{
     func insertNotification(notification: AppNotification) throws {
         let insertSql = """
                         INSERT INTO notifications (
-                                notification_id, task_id, datetime, is_limit
+                                notification_id, task_id, delay, is_limit
                             )
                             VALUES
                             (?, ?, ?, ?);
@@ -102,14 +102,9 @@ final class NotificationDB{
             throw TaskDatabaseError.insertTaskFailed(errorMessage)
         }
         
-        // Date型をString型に変換
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        let dateString = formatter.string(from: notification.datetime)
-        
         sqlite3_bind_text(insertStmt, 1, (notification.notificationId as NSString).utf8String, -1, nil)
         sqlite3_bind_text(insertStmt, 2, (notification.taskId as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(insertStmt, 3, (dateString as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(insertStmt, 3, Int32(notification.delay))
         sqlite3_bind_int(insertStmt, 4, Int32(notification.isLimit ? 1 : 0))
         
         if sqlite3_step(insertStmt) != SQLITE_DONE {
@@ -142,7 +137,7 @@ final class NotificationDB{
         let updateSql = """
         UPDATE  notifications
         SET     task_id = ?,
-                datetime = ?,
+                delay = ?,
                 is_limit = ?
         WHERE   notification_id = ?
         """
@@ -153,13 +148,8 @@ final class NotificationDB{
             throw NotificationDatabaseError.updateNotificationFailed(errorMessage)
         }
         
-        // Date型をString型に変換
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        let dateString = formatter.string(from: notification.datetime)
-        
         sqlite3_bind_text(updateStmt, 1, (notification.taskId as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(updateStmt, 2, (dateString as NSString).utf8String, -1, nil)
+        sqlite3_bind_int(updateStmt, 2, Int32(notification.delay))
         sqlite3_bind_int(updateStmt, 3, Int32(notification.isLimit ? 1 : 0))
         
         sqlite3_bind_text(updateStmt, 4, (notification.notificationId as NSString).utf8String, -1, nil)
@@ -192,23 +182,13 @@ final class NotificationDB{
         
         sqlite3_bind_text(stmt, 1, (taskId as NSString).utf8String, -1, nil)
         
-        // String型をDate型に変換
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        formatter.locale = Locale(identifier: "ja_JP")
-        
         while sqlite3_step(stmt) == SQLITE_ROW {
             let notificationId = String(describing: String(cString: sqlite3_column_text(stmt, 0)))
             let taskId = String(describing: String(cString: sqlite3_column_text(stmt, 1)))
-            
-            guard let datetime = formatter.date(from: String(cString: sqlite3_column_text(stmt, 2))) else {
-                let errorMessage = "value error: deadline null"
-                throw NotificationDatabaseError.getNotificationsFailed(errorMessage)
-            }
-            
+            let delay = Int(sqlite3_column_int(stmt, 2))
             let isLimit = sqlite3_column_int(stmt, 3)==1 ? true : false
             
-            let notification = AppNotification(notificationId:notificationId,taskId:taskId,datetime:datetime,isLimit:isLimit)
+            let notification = AppNotification(notificationId:notificationId,taskId:taskId,delay:delay,isLimit:isLimit)
             
             notifications.append(notification)
         }

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -100,7 +100,7 @@ final class NotificationManager {
     func sendNotifications(task: Task, notifications: [AppNotification]) {
         for notification in notifications {
             // 通知に載せるメッセージを作成
-            var message: String = "\(task.name)"
+            var message: String = "タスク \(task.name) "
             let deadline = Calendar.current.startOfDay(for: task.deadline)
             if notification.isLimit {
                 message = message + "の期限です"

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -14,41 +14,44 @@ final class NotificationManager {
     func createNotification(task: Task) -> [AppNotification] {
         var notifications: [AppNotification] = []
         
+        // 期限までの秒数を取得
+        let deadlineDelay = Int(task.deadline.timeIntervalSinceNow)
+        
         if task.isPreNotified {
-            // 最初に通知が来る日時を取得
-            var firstDatetime: Date = Date()
+            // 最初に通知が来るまでの秒数を取得
+            var firstDelay: Int = 0
             if task.firstNotifiedNum != nil {
                 if task.firstNotifiedRange=="時間" {
-                    firstDatetime = calendar.date(byAdding:.hour, value:-1*task.firstNotifiedNum!, to: task.deadline)!
+                    firstDelay = deadlineDelay - task.firstNotifiedNum!*60*60
                 }
                 if task.firstNotifiedRange=="日" {
-                    firstDatetime = calendar.date(byAdding:.day, value:-1*task.firstNotifiedNum!, to: task.deadline)!
+                    firstDelay = deadlineDelay - task.firstNotifiedNum!*60*60*24
                 }
                 if task.firstNotifiedRange=="週間" {
-                    firstDatetime = calendar.date(byAdding:.weekOfYear, value:-1*task.firstNotifiedNum!, to: task.deadline)!
+                    firstDelay = deadlineDelay - task.firstNotifiedNum!*60*60*24*7
                 }
             }
             // 繰り返し来る通知を作成
-            var intervalDatetime = firstDatetime
+            var intervalDelay = firstDelay
             if task.intervalNotifiedNum != nil {
-                while intervalDatetime < task.deadline {
-                    let notification = AppNotification(notificationId:UUID().uuidString,taskId:task.taskId,datetime:intervalDatetime,isLimit:false)
+                while intervalDelay < deadlineDelay {
+                    let notification = AppNotification(notificationId:UUID().uuidString,taskId:task.taskId,delay:intervalDelay,isLimit:false)
                     notifications.append(notification)
                     if task.intervalNotifiedRange=="時間" {
-                        intervalDatetime = calendar.date(byAdding:.hour, value:task.intervalNotifiedNum!, to: intervalDatetime)!
+                        intervalDelay = intervalDelay + task.intervalNotifiedNum!*60*60
                     }
                     if task.intervalNotifiedRange=="日" {
-                        intervalDatetime = calendar.date(byAdding:.day, value:task.intervalNotifiedNum!, to: intervalDatetime)!
+                        intervalDelay = intervalDelay + task.intervalNotifiedNum!*60*60*24
                     }
                     if task.intervalNotifiedRange=="週間" {
-                        intervalDatetime = calendar.date(byAdding:.weekOfYear, value:task.intervalNotifiedNum!, to: intervalDatetime)!
+                        intervalDelay = intervalDelay + task.intervalNotifiedNum!*60*60*24*7
                     }
                 }
             }
         }
         // 締め切り時に来る通知を作成
         if task.isLimitNotified {
-            let notification = AppNotification(notificationId:UUID().uuidString,taskId:task.taskId,datetime:task.deadline,isLimit:true)
+            let notification = AppNotification(notificationId:UUID().uuidString,taskId:task.taskId,delay:deadlineDelay,isLimit:true)
             notifications.append(notification)
         }
         
@@ -60,32 +63,32 @@ final class NotificationManager {
     ///   - task: 対象のタスク
     ///   - notifications: 変更前の通知が入った配列
     /// - Returns: isNeededDelete:  削除が必要か否か, mergedNotifications: マージ後の通知が入った配列 (変更の必要がなければ空の配列が返る)
-    func mergeNotification(task: Task, notifications: [AppNotification]) -> (isNeededDelete: Bool, mergedNotifications: [AppNotification]) {
-        var updatedNotifications = createNotification(task:task)
-        var mergedNotifications: [AppNotification] = []
-        if notifications.count == updatedNotifications.count {
-            // 通知の数が同じ場合さらに詳細を比較し、必要があれば更新
-            for i in 0 ..< notifications.count {
-                if calendar.isDate(notifications[i].datetime, equalTo: updatedNotifications[i].datetime, toGranularity: .second) {
-                    if notifications[i].isLimit == updatedNotifications[i].isLimit {
-                        continue
-                    }
-                }
-                updatedNotifications[i].notificationId = notifications[i].notificationId
-                mergedNotifications.append(updatedNotifications[i])
-            }
-            return (false, mergedNotifications)
-        } else {
-            // 通知の数が違う場合、変更前の通知を削除して変更後の通知を追加
-            return (true, updatedNotifications)
-        }
-    }
+//    func mergeNotification(task: Task, notifications: [AppNotification]) -> (isNeededDelete: Bool, mergedNotifications: [AppNotification]) {
+//        var updatedNotifications = createNotification(task:task)
+//        var mergedNotifications: [AppNotification] = []
+//        if notifications.count == updatedNotifications.count {
+//            // 通知の数が同じ場合さらに詳細を比較し、必要があれば更新
+//            for i in 0 ..< notifications.count {
+//                if calendar.isDate(notifications[i].datetime, equalTo: updatedNotifications[i].datetime, toGranularity: .second) {
+//                    if notifications[i].isLimit == updatedNotifications[i].isLimit {
+//                        continue
+//                    }
+//                }
+//                updatedNotifications[i].notificationId = notifications[i].notificationId
+//                mergedNotifications.append(updatedNotifications[i])
+//            }
+//            return (false, mergedNotifications)
+//        } else {
+//            // 通知の数が違う場合、変更前の通知を削除して変更後の通知を追加
+//            return (true, updatedNotifications)
+//        }
+//    }
     
-    func calcRemainingMessage(deadline: Date, date: Date) -> String {
+    func createMessage(delay: Int) -> String {
         var message: String = ""
-        let remainingDays = Calendar.current.dateComponents([.day], from: date, to: deadline).day!
+        let remainingDays = Int(delay/(60*60*24))
         if remainingDays <= 1 {
-            let remainingHours = Calendar.current.dateComponents([.hour], from: date, to: deadline).hour!
+            let remainingHours = Int(delay/(60*60))
             message = "まであと\(remainingHours)時間です"
         } else if remainingDays % 7 == 0 {
             let remainingWeeks = Int(remainingDays/7)
@@ -101,20 +104,18 @@ final class NotificationManager {
         for notification in notifications {
             // 通知に載せるメッセージを作成
             var message: String = "タスク \(task.name) "
-            let deadline = Calendar.current.startOfDay(for: task.deadline)
             if notification.isLimit {
                 message = message + "の期限です"
             } else {
-                let date = Calendar.current.startOfDay(for: notification.datetime)
-                message = message + calcRemainingMessage(deadline: deadline, date: date)
+                message = message + createMessage(delay: notification.delay)
             }
             // 通知を作成
             let content = UNMutableNotificationContent()
             content.body = message
             content.sound = UNNotificationSound.default
             // 通知を登録
-            let dateComponent = Calendar.current.dateComponents(in: TimeZone.current, from: notification.datetime)
-            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponent, repeats: false)
+            let interval = TimeInterval(notification.delay)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
             let request = UNNotificationRequest(identifier: notification.notificationId, content: content, trigger: trigger)
             UNUserNotificationCenter.current().add(request) { (error: Error?) in
                 if error != nil {

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -87,9 +87,14 @@ final class NotificationManager {
     func createMessage(delay: Int) -> String {
         var message: String = ""
         let remainingDays = Int(delay/(60*60*24))
-        if remainingDays <= 1 {
+        if remainingDays < 1 {
             let remainingHours = Int(delay/(60*60))
-            message = "まであと\(remainingHours)時間です"
+            if remainingHours == 0 {
+                // わずかに1時間を切ってしまった時
+                message = "まであと1時間です"
+            } else {
+                message = "まであと\(remainingHours)時間です"
+            }
         } else if remainingDays % 7 == 0 {
             let remainingWeeks = Int(remainingDays/7)
             message = "まであと\(remainingWeeks)週間です"

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -17,6 +17,9 @@ final class NotificationManager {
         // 期限までの秒数を取得
         let deadlineDelay = Int(task.deadline.timeIntervalSinceNow)
         
+        // 期限を過ぎている場合は通知を作成しない
+        guard deadlineDelay > 0 else { return [] }
+        
         if task.isPreNotified {
             // 最初に通知が来るまでの秒数を取得
             var firstDelay: Int = 0
@@ -36,7 +39,10 @@ final class NotificationManager {
             if task.intervalNotifiedNum != nil {
                 while intervalDelay < deadlineDelay {
                     let notification = AppNotification(notificationId:UUID().uuidString,taskId:task.taskId,delay:intervalDelay,isLimit:false)
-                    notifications.append(notification)
+                    // 通知時刻を過ぎていない場合のみ通知を作成
+                    if intervalDelay > 0 {
+                        notifications.append(notification)
+                    }
                     if task.intervalNotifiedRange=="時間" {
                         intervalDelay = intervalDelay + task.intervalNotifiedNum!*60*60
                     }

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -63,26 +63,26 @@ final class NotificationManager {
     ///   - task: 対象のタスク
     ///   - notifications: 変更前の通知が入った配列
     /// - Returns: isNeededDelete:  削除が必要か否か, mergedNotifications: マージ後の通知が入った配列 (変更の必要がなければ空の配列が返る)
-//    func mergeNotification(task: Task, notifications: [AppNotification]) -> (isNeededDelete: Bool, mergedNotifications: [AppNotification]) {
-//        var updatedNotifications = createNotification(task:task)
-//        var mergedNotifications: [AppNotification] = []
-//        if notifications.count == updatedNotifications.count {
-//            // 通知の数が同じ場合さらに詳細を比較し、必要があれば更新
-//            for i in 0 ..< notifications.count {
-//                if calendar.isDate(notifications[i].datetime, equalTo: updatedNotifications[i].datetime, toGranularity: .second) {
-//                    if notifications[i].isLimit == updatedNotifications[i].isLimit {
-//                        continue
-//                    }
-//                }
-//                updatedNotifications[i].notificationId = notifications[i].notificationId
-//                mergedNotifications.append(updatedNotifications[i])
-//            }
-//            return (false, mergedNotifications)
-//        } else {
-//            // 通知の数が違う場合、変更前の通知を削除して変更後の通知を追加
-//            return (true, updatedNotifications)
-//        }
-//    }
+    func mergeNotification(task: Task, notifications: [AppNotification]) -> (isNeededDelete: Bool, mergedNotifications: [AppNotification]) {
+        var updatedNotifications = createNotification(task:task)
+        var mergedNotifications: [AppNotification] = []
+        if notifications.count == updatedNotifications.count {
+            // 通知の数が同じ場合さらに詳細を比較し、必要があれば更新
+            for i in 0 ..< notifications.count {
+                if abs(notifications[i].delay - updatedNotifications[i].delay) < 60 {
+                    if notifications[i].isLimit == updatedNotifications[i].isLimit {
+                        continue
+                    }
+                }
+                updatedNotifications[i].notificationId = notifications[i].notificationId
+                mergedNotifications.append(updatedNotifications[i])
+            }
+            return (false, mergedNotifications)
+        } else {
+            // 通知の数が違う場合、変更前の通知を削除して変更後の通知を追加
+            return (true, updatedNotifications)
+        }
+    }
     
     func createMessage(delay: Int) -> String {
         var message: String = ""

--- a/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
+++ b/RepeatReminder/RepeatReminder/Domain/Usecases/NotificationManager.swift
@@ -86,15 +86,10 @@ final class NotificationManager {
     
     func createMessage(delay: Int) -> String {
         var message: String = ""
-        let remainingDays = Int(delay/(60*60*24))
-        if remainingDays < 1 {
+        let remainingDays = Int(delay/(60*60*24))+1
+        if remainingDays <= 1 {
             let remainingHours = Int(delay/(60*60))
-            if remainingHours == 0 {
-                // わずかに1時間を切ってしまった時
-                message = "まであと1時間です"
-            } else {
-                message = "まであと\(remainingHours)時間です"
-            }
+            message = "まであと\(remainingHours+1)時間です"
         } else if remainingDays % 7 == 0 {
             let remainingWeeks = Int(remainingDays/7)
             message = "まであと\(remainingWeeks)週間です"
@@ -112,7 +107,8 @@ final class NotificationManager {
             if notification.isLimit {
                 message = message + "の期限です"
             } else {
-                message = message + createMessage(delay: notification.delay)
+                let remaining = Int(task.deadline.timeIntervalSinceNow) - Int(notification.delay)
+                message = message + createMessage(delay: remaining)
             }
             // 通知を作成
             let content = UNMutableNotificationContent()

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/SettingListViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/SettingListViewModel.swift
@@ -43,6 +43,7 @@ class SettingListViewModel: ObservableObject {
         for notification in notifications {
             try! notificationDb.insertNotification(notification:notification)
         }
+        manager.sendNotifications(task: task, notifications: notifications)
         readTask()
     }
     
@@ -59,6 +60,7 @@ class SettingListViewModel: ObservableObject {
         for notification in notifications {
             try! notificationDb.insertNotification(notification:notification)
         }
+        manager.sendNotifications(task: task, notifications: notifications)
         readTask()
     }
     

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
@@ -23,7 +23,7 @@ class TaskAddEditViewModel: ObservableObject,Identifiable {
     @Published var selectedIntervalNum = 1
     @Published var selectedIntervalRange = "時間"
     
-    var manager = NotificationManager()
+    let manager = NotificationManager()
     let initialTask = Task(taskId:UUID().uuidString,name:"",deadline:Date(),
                            isLimitNotified:true,isPreNotified:true,
                            firstNotifiedNum:1,firstNotifiedRange:"時間",

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
@@ -73,29 +73,29 @@ class TaskAddEditViewModel: ObservableObject,Identifiable {
         // タスクをデータベース上で更新
         try! taskDb.updateTask(task:task)
         // 通知関連で変更があるか調べる
-        let notifications = try! notificationDb.getNotifications(taskId: task.taskId)
-        let result = manager.mergeNotification(task:task, notifications:notifications)
-        if result.isNeededDelete {
-            // 以前登録した通知の削除が必要な場合、変更前の通知を削除して変更後の通知を追加
-            // 削除
-            try! notificationDb.deleteNotification(taskId: task.taskId)
-            var notificationIds: [String] = []
-            for notification in notifications {
-                notificationIds.append(notification.notificationId)
-            }
-            manager.removeNotification(id: notificationIds)
-            // 追加
-            for notification in result.mergedNotifications {
-                try! notificationDb.insertNotification(notification: notification)
-            }
-            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
-        } else {
-            // 以前登録した通知の削除が不要な場合、通知を更新
-            for notification in result.mergedNotifications {
-                try! notificationDb.updateNotification(notification: notification)
-            }
-            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
-        }
+//        let notifications = try! notificationDb.getNotifications(taskId: task.taskId)
+//        let result = manager.mergeNotification(task:task, notifications:notifications)
+//        if result.isNeededDelete {
+//            // 以前登録した通知の削除が必要な場合、変更前の通知を削除して変更後の通知を追加
+//            // 削除
+//            try! notificationDb.deleteNotification(taskId: task.taskId)
+//            var notificationIds: [String] = []
+//            for notification in notifications {
+//                notificationIds.append(notification.notificationId)
+//            }
+//            manager.removeNotification(id: notificationIds)
+//            // 追加
+//            for notification in result.mergedNotifications {
+//                try! notificationDb.insertNotification(notification: notification)
+//            }
+//            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
+//        } else {
+//            // 以前登録した通知の削除が不要な場合、通知を更新
+//            for notification in result.mergedNotifications {
+//                try! notificationDb.updateNotification(notification: notification)
+//            }
+//            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
+//        }
     }
     
     func deleteTask() {

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskAddEditViewModel.swift
@@ -73,29 +73,29 @@ class TaskAddEditViewModel: ObservableObject,Identifiable {
         // タスクをデータベース上で更新
         try! taskDb.updateTask(task:task)
         // 通知関連で変更があるか調べる
-//        let notifications = try! notificationDb.getNotifications(taskId: task.taskId)
-//        let result = manager.mergeNotification(task:task, notifications:notifications)
-//        if result.isNeededDelete {
-//            // 以前登録した通知の削除が必要な場合、変更前の通知を削除して変更後の通知を追加
-//            // 削除
-//            try! notificationDb.deleteNotification(taskId: task.taskId)
-//            var notificationIds: [String] = []
-//            for notification in notifications {
-//                notificationIds.append(notification.notificationId)
-//            }
-//            manager.removeNotification(id: notificationIds)
-//            // 追加
-//            for notification in result.mergedNotifications {
-//                try! notificationDb.insertNotification(notification: notification)
-//            }
-//            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
-//        } else {
-//            // 以前登録した通知の削除が不要な場合、通知を更新
-//            for notification in result.mergedNotifications {
-//                try! notificationDb.updateNotification(notification: notification)
-//            }
-//            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
-//        }
+        let notifications = try! notificationDb.getNotifications(taskId: task.taskId)
+        let result = manager.mergeNotification(task:task, notifications:notifications)
+        if result.isNeededDelete {
+            // 以前登録した通知の削除が必要な場合、変更前の通知を削除して変更後の通知を追加
+            // 削除
+            try! notificationDb.deleteNotification(taskId: task.taskId)
+            var notificationIds: [String] = []
+            for notification in notifications {
+                notificationIds.append(notification.notificationId)
+            }
+            manager.removeNotification(id: notificationIds)
+            // 追加
+            for notification in result.mergedNotifications {
+                try! notificationDb.insertNotification(notification: notification)
+            }
+            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
+        } else {
+            // 以前登録した通知の削除が不要な場合、通知を更新
+            for notification in result.mergedNotifications {
+                try! notificationDb.updateNotification(notification: notification)
+            }
+            manager.sendNotifications(task: task, notifications: result.mergedNotifications)
+        }
     }
     
     func deleteTask() {

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskCellViewModel.swift
@@ -54,7 +54,7 @@ class TaskCellViewModel: ObservableObject {
     
     var remainingNumText: Text {
         var remaining = ""
-        if remainingDays < 365 {
+        if ( remainingDays < 365 && remainingDays > -365 ) {
             remaining = String(abs(remainingDays))
         } else {
             remaining = String(abs(remainingYears))
@@ -68,7 +68,7 @@ class TaskCellViewModel: ObservableObject {
     
     var remainingText: String {
         var remaining = ""
-        if remainingDays < 365 {
+        if ( remainingDays < 365 && remainingDays > -365 ) {
             remaining = "日"
         } else {
             remaining = "年"

--- a/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskListViewModel.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/ViewModels/TaskListViewModel.swift
@@ -32,12 +32,22 @@ class TaskListViewModel: ObservableObject {
         guard let taskDb = TaskDB.shared else {
             return
         }
+        // タスクをデータベース上で更新
         var completedTask = task
         completedTask.isCompleted = true
         try! taskDb.updateTask(task:completedTask)
+        // 削除する通知に関する情報を取得してシステムから通知を削除
         guard let notificationDb = NotificationDB.shared else {
             return
         }
+        let notifications = try! notificationDb.getNotifications(taskId: task.taskId)
+        var notificationIds: [String] = []
+        for notification in notifications {
+            notificationIds.append(notification.notificationId)
+        }
+        let manager = NotificationManager()
+        manager.removeNotification(id: notificationIds)
+        // 通知をデータベースから削除
         try! notificationDb.deleteNotification(taskId: task.taskId)
         readTask()
     }

--- a/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
@@ -256,8 +256,6 @@ struct TaskAddEditView: View {
                         }
                     }
                 }
-            }.onTapGesture {
-                focusedField = nil
             }
         }
     }

--- a/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
@@ -14,6 +14,7 @@ struct TaskAddEditView: View {
     @FocusState private var focusedField: Bool?
     @ObservedObject var viewModel = TaskAddEditViewModel()
     @State private var isShowedAlert = false
+    @State private var isShowedCheck = false
     
     let nums = [1,2,3,4,5,6,7,8,9,10]
     let ranges = ["時間","日","週間"]
@@ -199,12 +200,16 @@ struct TaskAddEditView: View {
                                 .shadow(color:.gray,radius:5,x:0,y:8)
                         }
                         Button(action:{
-                            self.presentation.wrappedValue.dismiss()
                             print("tap add or edit button")
-                            if isEditing {
-                                viewModel.updateTask()
+                            if viewModel.task.deadline < Date() {
+                                isShowedCheck = true
                             } else {
-                                viewModel.addTask()
+                                self.presentation.wrappedValue.dismiss()
+                                if isEditing {
+                                    viewModel.updateTask()
+                                } else {
+                                    viewModel.addTask()
+                                }
                             }
                         }){
                             if isEditing {
@@ -229,6 +234,21 @@ struct TaskAddEditView: View {
                                     .shadow(color:.gray,radius:5,x:0,y:8)
                             }
                         }
+                    }.alert("期限を過ぎています\nこのまま保存しますか？", isPresented: $isShowedCheck) {
+                        Button("保存") {
+                            isShowedCheck = false
+                            self.presentation.wrappedValue.dismiss()
+                            if isEditing {
+                                viewModel.updateTask()
+                            } else {
+                                viewModel.addTask()
+                            }
+                        }
+                        Button("キャンセル",role:.cancel) {
+                            isShowedCheck = false
+                        }
+                    } message: {
+                        Text("タスク一覧には表示されます")
                     }
                     Spacer()
                     if isEditing {

--- a/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
+++ b/RepeatReminder/RepeatReminder/Presentation/Views/TaskAddEditView.swift
@@ -11,7 +11,6 @@ struct TaskAddEditView: View {
     let isEditing: Bool
     
     @Environment(\.presentationMode) var presentation
-    @FocusState private var focusedField: Bool?
     @ObservedObject var viewModel = TaskAddEditViewModel()
     @State private var isShowedAlert = false
     @State private var isShowedCheck = false
@@ -61,7 +60,6 @@ struct TaskAddEditView: View {
                                 .foregroundColor(Color("TextColor"))
                                 .frame(width:120,height:4)
                                 .padding()
-                                .focused($focusedField, equals:true)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 5)
                                         .stroke(Color("MainColor"), lineWidth: 1)

--- a/RepeatReminder/RepeatReminder/development.entitlements
+++ b/RepeatReminder/RepeatReminder/development.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/RepeatReminder/RepeatReminder/production.entitlements
+++ b/RepeatReminder/RepeatReminder/production.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+</dict>
+</plist>

--- a/RepeatReminder/RepeatReminderTests/NotificationDBTests.swift
+++ b/RepeatReminder/RepeatReminderTests/NotificationDBTests.swift
@@ -16,7 +16,7 @@ final class NotificationDBTests: XCTestCase {
     override func setUpWithError() throws {
         super.setUp()
         db = NotificationDB.shared
-        notification = AppNotification(notificationId:UUID().uuidString,taskId:UUID().uuidString,datetime:Date(),isLimit:true)
+        notification = AppNotification(notificationId:UUID().uuidString,taskId:UUID().uuidString,delay:60,isLimit:true)
     }
     
     override func tearDownWithError() throws {
@@ -49,7 +49,7 @@ final class NotificationDBTests: XCTestCase {
     func testUpdateNotification() {
         XCTAssertNoThrow(try db.insertNotification(notification: notification), "Insert notification should be successfull")
         
-        let notificationUpdated = AppNotification(notificationId:notification.notificationId,taskId:notification.taskId, datetime:Date(),isLimit:false)
+        let notificationUpdated = AppNotification(notificationId:notification.notificationId,taskId:notification.taskId,delay:60,isLimit:false)
         
         XCTAssertNoThrow(try db.updateNotification(notification: notificationUpdated), "Update notification should be successful")
     }
@@ -57,7 +57,7 @@ final class NotificationDBTests: XCTestCase {
     func testUpdateNotificationFailed() {
         XCTAssertNoThrow(try db.insertNotification(notification: notification), "Insert notification should be successfull")
         
-        let notificationUpdatedFailed = AppNotification(notificationId:UUID().uuidString,taskId:notification.taskId, datetime:Date(),isLimit:false)
+        let notificationUpdatedFailed = AppNotification(notificationId:UUID().uuidString,taskId:notification.taskId,delay:60,isLimit:false)
         
         XCTAssertThrowsError(try db.updateNotification(notification: notificationUpdatedFailed), "Update notification should be failed")
     }

--- a/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
+++ b/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
@@ -43,90 +43,92 @@ final class NotificationManagerTests: XCTestCase {
     
     func testCreateDeadlineNotification() throws {
         let result = manager.createNotification(task: task1)
+        let interval = Int(task1.deadline.timeIntervalSinceNow)
         XCTAssertEqual(result.count, 1, "Notification should be one")
         XCTAssertEqual(result[0].taskId, task1.taskId, "Created notification's taskId is correct one")
-        XCTAssertEqual(result[0].datetime, task1.deadline, "Created notification's datetime is correct one")
+        XCTAssertEqual(result[0].delay, interval, "Created notification's datetime is correct one")
         XCTAssertTrue(result[0].isLimit, "Created notification is deadline notification")
     }
     
     func testCreateRepeatNotification() throws {
         let calendar = Calendar(identifier: .gregorian)
         
-        let datetime1 = calendar.date(byAdding:.day, value:-14, to: task2.deadline)!
-        let datetime2 = calendar.date(byAdding:.day, value:-7, to: task2.deadline)!
+        let interval = Int(task2.deadline.timeIntervalSinceNow)
+        let delay1 = interval - 14*60*60*24
+        let delay2 = interval - 7*60*60*24
         
         let result = manager.createNotification(task: task2)
         XCTAssertEqual(result.count, 3, "Notification should be three")
-        XCTAssertEqual(result[0].datetime, datetime1, "Created notification's datetime is correct one")
+        XCTAssertEqual(result[0].delay, delay1, "Created notification's datetime is correct one")
         XCTAssertFalse(result[0].isLimit, "Created notification is not deadline notification")
-        XCTAssertEqual(result[1].datetime, datetime2, "Created notification's datetime is correct one")
+        XCTAssertEqual(result[1].delay, delay2, "Created notification's datetime is correct one")
         XCTAssertFalse(result[1].isLimit, "Created notification is not deadline notification")
-        XCTAssertEqual(result[2].datetime, task2.deadline, "Created notification's datetime is correct one")
+        XCTAssertEqual(result[2].delay, interval, "Created notification's datetime is correct one")
         XCTAssertTrue(result[2].isLimit, "Created notification is deadline notification")
     }
     
-    func testUpdateNotificationNoChanged() throws {
-        // タスク1の通知を追加
-        let result1 = manager.createNotification(task: task1)
-        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-        
-        var notifications: [AppNotification] = []
-        
-        // 通知に関係のない変更があった場合
-        task1.name = "Updated Deadline Task"
-        
-        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
-        XCTAssertEqual(result2.mergedNotifications.count, 0, "Notification doesn't needed to be updated")
-    }
+//    func testUpdateNotificationNoChanged() throws {
+//        // タスク1の通知を追加
+//        let result1 = manager.createNotification(task: task1)
+//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+//        
+//        var notifications: [AppNotification] = []
+//        
+//        // 通知に関係のない変更があった場合
+//        task1.name = "Updated Deadline Task"
+//        
+//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+//        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
+//        XCTAssertEqual(result2.mergedNotifications.count, 0, "Notification doesn't needed to be updated")
+//    }
     
-    func testUpdateNotificationChangedDeadline() throws {
-        // タスク1の通知を追加
-        let result1 = manager.createNotification(task: task1)
-        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-        
-        var notifications: [AppNotification] = []
-        
-        // 通知に関する変更があった場合(通知の個数は変化しない)
-        let calendar = Calendar(identifier: .gregorian)
-        task1.deadline = calendar.date(byAdding:.day, value:1, to: task1.deadline)!
-        
-        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
-        XCTAssertEqual(result2.mergedNotifications.count, 1, "Notification need to be updated")
-        XCTAssertEqual(result2.mergedNotifications[0].datetime, task1.deadline, "Created notification's datetime is correct one")
-    }
+//    func testUpdateNotificationChangedDeadline() throws {
+//        // タスク1の通知を追加
+//        let result1 = manager.createNotification(task: task1)
+//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+//        
+//        var notifications: [AppNotification] = []
+//        
+//        // 通知に関する変更があった場合(通知の個数は変化しない)
+//        let calendar = Calendar(identifier: .gregorian)
+//        task1.deadline = calendar.date(byAdding:.day, value:1, to: task1.deadline)!
+//        
+//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+//        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
+//        XCTAssertEqual(result2.mergedNotifications.count, 1, "Notification need to be updated")
+//        XCTAssertEqual(result2.mergedNotifications[0].datetime, task1.deadline, "Created notification's datetime is correct one")
+//    }
     
-    func testUpdateNotificationChangedRepeat() throws {
-        // タスク1の通知を追加
-        let result1 = manager.createNotification(task: task1)
-        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-        
-        var notifications: [AppNotification] = []
-        
-        // 通知に関する変更があった場合(通知の個数が変化する)
-        task1.isPreNotified = true
-        task1.firstNotifiedNum = 2
-        task1.firstNotifiedRange = "時間"
-        task1.intervalNotifiedNum = 1
-        task1.intervalNotifiedRange = "時間"
-        
-        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-        XCTAssertTrue(result2.isNeededDelete, "Notification need to be deleted")
-        XCTAssertEqual(result2.mergedNotifications.count, 3, "Notifications need to be updated")
-        
-        let calendar = Calendar(identifier: .gregorian)
-        
-        let datetime1 = calendar.date(byAdding:.hour, value:-2, to: task1.deadline)!
-        let datetime2 = calendar.date(byAdding:.hour, value:-1, to: task1.deadline)!
-        
-        XCTAssertEqual(result2.mergedNotifications[0].datetime, datetime1, "Created notification's datetime is correct one")
-        XCTAssertEqual(result2.mergedNotifications[1].datetime, datetime2, "Created notification's datetime is correct one")
-        XCTAssertEqual(result2.mergedNotifications[2].datetime, task1.deadline, "Created notification's datetime is correct one")
-    }
+//    func testUpdateNotificationChangedRepeat() throws {
+//        // タスク1の通知を追加
+//        let result1 = manager.createNotification(task: task1)
+//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+//        
+//        var notifications: [AppNotification] = []
+//        
+//        // 通知に関する変更があった場合(通知の個数が変化する)
+//        task1.isPreNotified = true
+//        task1.firstNotifiedNum = 2
+//        task1.firstNotifiedRange = "時間"
+//        task1.intervalNotifiedNum = 1
+//        task1.intervalNotifiedRange = "時間"
+//        
+//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+//        XCTAssertTrue(result2.isNeededDelete, "Notification need to be deleted")
+//        XCTAssertEqual(result2.mergedNotifications.count, 3, "Notifications need to be updated")
+//        
+//        let calendar = Calendar(identifier: .gregorian)
+//        
+//        let datetime1 = calendar.date(byAdding:.hour, value:-2, to: task1.deadline)!
+//        let datetime2 = calendar.date(byAdding:.hour, value:-1, to: task1.deadline)!
+//        
+//        XCTAssertEqual(result2.mergedNotifications[0].datetime, datetime1, "Created notification's datetime is correct one")
+//        XCTAssertEqual(result2.mergedNotifications[1].datetime, datetime2, "Created notification's datetime is correct one")
+//        XCTAssertEqual(result2.mergedNotifications[2].datetime, task1.deadline, "Created notification's datetime is correct one")
+//    }
     
     func testPerformanceExample() throws {
         // This is an example of a performance test case.

--- a/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
+++ b/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
@@ -51,8 +51,6 @@ final class NotificationManagerTests: XCTestCase {
     }
     
     func testCreateRepeatNotification() throws {
-        let calendar = Calendar(identifier: .gregorian)
-        
         let interval = Int(task2.deadline.timeIntervalSinceNow)
         let delay1 = interval - 14*60*60*24
         let delay2 = interval - 7*60*60*24
@@ -65,6 +63,36 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertFalse(result[1].isLimit, "Created notification is not deadline notification")
         XCTAssertEqual(result[2].delay, interval, "Created notification's datetime is correct one")
         XCTAssertTrue(result[2].isLimit, "Created notification is deadline notification")
+    }
+    
+    func testCreateMessage() throws {
+        let delay0 = 60*50
+        let message0 = manager.createMessage(delay: delay0)
+        XCTAssertEqual(message0, "まであと1時間です")
+        
+        let delay1 = 60*60
+        let message1 = manager.createMessage(delay: delay1)
+        XCTAssertEqual(message1, "まであと1時間です")
+        
+        let delay2 = 60*60*12
+        let message2 = manager.createMessage(delay: delay2)
+        XCTAssertEqual(message2, "まであと12時間です")
+        
+        let delay3 = 60*60*24
+        let message3 = manager.createMessage(delay: delay3)
+        XCTAssertEqual(message3, "まであと1日です")
+        
+        let delay4 = 60*60*24*4
+        let message4 = manager.createMessage(delay: delay4)
+        XCTAssertEqual(message4, "まであと4日です")
+        
+        let delay5 = 60*60*24*7
+        let message5 = manager.createMessage(delay: delay5)
+        XCTAssertEqual(message5, "まであと1週間です")
+        
+        let delay6 = 60*60*24*8
+        let message6 = manager.createMessage(delay: delay6)
+        XCTAssertEqual(message6, "まであと8日です")
     }
     
 //    func testUpdateNotificationNoChanged() throws {

--- a/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
+++ b/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
@@ -66,31 +66,31 @@ final class NotificationManagerTests: XCTestCase {
     }
     
     func testCreateMessage() throws {
-        let delay0 = 60*50
+        let delay0 = 60*50-30
         let message0 = manager.createMessage(delay: delay0)
         XCTAssertEqual(message0, "まであと1時間です")
         
-        let delay1 = 60*60
+        let delay1 = 60*60-30
         let message1 = manager.createMessage(delay: delay1)
         XCTAssertEqual(message1, "まであと1時間です")
         
-        let delay2 = 60*60*12
+        let delay2 = 60*60*12-30
         let message2 = manager.createMessage(delay: delay2)
         XCTAssertEqual(message2, "まであと12時間です")
         
-        let delay3 = 60*60*24
+        let delay3 = 60*60*24-30
         let message3 = manager.createMessage(delay: delay3)
-        XCTAssertEqual(message3, "まであと1日です")
+        XCTAssertEqual(message3, "まであと24時間です")
         
-        let delay4 = 60*60*24*4
+        let delay4 = 60*60*24*4-30
         let message4 = manager.createMessage(delay: delay4)
         XCTAssertEqual(message4, "まであと4日です")
         
-        let delay5 = 60*60*24*7
+        let delay5 = 60*60*24*7-30
         let message5 = manager.createMessage(delay: delay5)
         XCTAssertEqual(message5, "まであと1週間です")
         
-        let delay6 = 60*60*24*8
+        let delay6 = 60*60*24*8-30
         let message6 = manager.createMessage(delay: delay6)
         XCTAssertEqual(message6, "まであと8日です")
     }

--- a/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
+++ b/RepeatReminder/RepeatReminderTests/NotificationManagerTests.swift
@@ -95,68 +95,73 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertEqual(message6, "まであと8日です")
     }
     
-//    func testUpdateNotificationNoChanged() throws {
-//        // タスク1の通知を追加
-//        let result1 = manager.createNotification(task: task1)
-//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-//        
-//        var notifications: [AppNotification] = []
-//        
-//        // 通知に関係のない変更があった場合
-//        task1.name = "Updated Deadline Task"
-//        
-//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-//        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
-//        XCTAssertEqual(result2.mergedNotifications.count, 0, "Notification doesn't needed to be updated")
-//    }
+    func testUpdateNotificationNoChanged() throws {
+        // タスク1の通知を追加
+        let result1 = manager.createNotification(task: task1)
+        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+        
+        var notifications: [AppNotification] = []
+        
+        // 通知に関係のない変更があった場合
+        task1.name = "Updated Deadline Task"
+        
+        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
+        XCTAssertEqual(result2.mergedNotifications.count, 0, "Notification doesn't needed to be updated")
+    }
     
-//    func testUpdateNotificationChangedDeadline() throws {
-//        // タスク1の通知を追加
-//        let result1 = manager.createNotification(task: task1)
-//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-//        
-//        var notifications: [AppNotification] = []
-//        
-//        // 通知に関する変更があった場合(通知の個数は変化しない)
-//        let calendar = Calendar(identifier: .gregorian)
-//        task1.deadline = calendar.date(byAdding:.day, value:1, to: task1.deadline)!
-//        
-//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-//        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
-//        XCTAssertEqual(result2.mergedNotifications.count, 1, "Notification need to be updated")
-//        XCTAssertEqual(result2.mergedNotifications[0].datetime, task1.deadline, "Created notification's datetime is correct one")
-//    }
+    func testUpdateNotificationChangedDeadline() throws {
+        // タスク1の通知を追加
+        let result1 = manager.createNotification(task: task1)
+        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+        
+        var notifications: [AppNotification] = []
+        
+        // 通知に関する変更があった場合(通知の個数は変化しない)
+        let calendar = Calendar(identifier: .gregorian)
+        task1.deadline = calendar.date(byAdding:.day, value:1, to: task1.deadline)!
+        let interval = Int(task1.deadline.timeIntervalSinceNow)
+        
+        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+        XCTAssertFalse(result2.isNeededDelete, "Notification doesn't need to be deleted")
+        XCTAssertEqual(result2.mergedNotifications.count, 1, "Notification need to be updated")
+        XCTAssertEqual(result2.mergedNotifications[0].delay, interval, "Created notification's datetime is correct one")
+    }
     
-//    func testUpdateNotificationChangedRepeat() throws {
-//        // タスク1の通知を追加
-//        let result1 = manager.createNotification(task: task1)
-//        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
-//        
-//        var notifications: [AppNotification] = []
-//        
-//        // 通知に関する変更があった場合(通知の個数が変化する)
-//        task1.isPreNotified = true
-//        task1.firstNotifiedNum = 2
-//        task1.firstNotifiedRange = "時間"
-//        task1.intervalNotifiedNum = 1
-//        task1.intervalNotifiedRange = "時間"
-//        
-//        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
-//        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
-//        XCTAssertTrue(result2.isNeededDelete, "Notification need to be deleted")
-//        XCTAssertEqual(result2.mergedNotifications.count, 3, "Notifications need to be updated")
-//        
-//        let calendar = Calendar(identifier: .gregorian)
-//        
-//        let datetime1 = calendar.date(byAdding:.hour, value:-2, to: task1.deadline)!
-//        let datetime2 = calendar.date(byAdding:.hour, value:-1, to: task1.deadline)!
-//        
-//        XCTAssertEqual(result2.mergedNotifications[0].datetime, datetime1, "Created notification's datetime is correct one")
-//        XCTAssertEqual(result2.mergedNotifications[1].datetime, datetime2, "Created notification's datetime is correct one")
-//        XCTAssertEqual(result2.mergedNotifications[2].datetime, task1.deadline, "Created notification's datetime is correct one")
-//    }
+    func testUpdateNotificationChangedRepeat() throws {
+        // タスク1の通知を追加
+        let result1 = manager.createNotification(task: task1)
+        XCTAssertNoThrow(try db.insertNotification(notification: result1[0]), "Insert Notification should be successfull")
+        
+        var notifications: [AppNotification] = []
+        
+        // 通知に関する変更があった場合(通知の個数が変化する)
+        task1.isPreNotified = true
+        task1.firstNotifiedNum = 2
+        task1.firstNotifiedRange = "時間"
+        task1.intervalNotifiedNum = 1
+        task1.intervalNotifiedRange = "時間"
+        
+        XCTAssertNoThrow(notifications = try! db.getNotifications(taskId: task1.taskId), "Get Notification should be successfull")
+        let result2 = manager.mergeNotification(task:task1, notifications:notifications)
+        XCTAssertTrue(result2.isNeededDelete, "Notification need to be deleted")
+        XCTAssertEqual(result2.mergedNotifications.count, 3, "Notifications need to be updated")
+        
+        let calendar = Calendar(identifier: .gregorian)
+        
+        let datetime1 = calendar.date(byAdding:.hour, value:-2, to: task1.deadline)!
+        let datetime2 = calendar.date(byAdding:.hour, value:-1, to: task1.deadline)!
+        
+        let interval1 = Int(datetime1.timeIntervalSinceNow)
+        let interval2 = Int(datetime2.timeIntervalSinceNow)
+        let interval3 = Int(task1.deadline.timeIntervalSinceNow)
+        
+        XCTAssertEqual(result2.mergedNotifications[0].delay, interval1, "Created notification's datetime is correct one")
+        XCTAssertEqual(result2.mergedNotifications[1].delay, interval2, "Created notification's datetime is correct one")
+        XCTAssertEqual(result2.mergedNotifications[2].delay, interval3, "Created notification's datetime is correct one")
+    }
     
     func testPerformanceExample() throws {
         // This is an example of a performance test case.


### PR DESCRIPTION
## 概要
通知関連の不具合を修正

## 詳細
- 通知を登録しても来ない問題 -> ローカル通知を時刻指定にしていたのが原因
   -> 経過時間で指定したところ正常に通知された
- 経過時間で指定できるようにするために通知クラスAppNotificationやデータベースを修正
- 通知に表示するメッセージが残り時間を表すように修正・テスト
- 通知に関する情報をユーザーが変更したときの挙動を修正・テスト
- 期限を過ぎているタスクを作成しようとした時にアラートを表示・通知は登録しない
- 完了済・削除済のタスクを復元した時に通知を再登録するように修正

Closes #35